### PR TITLE
add condition, check if the freeshipping method is applicable and then remove other shipping methods with price greater than 0

### DIFF
--- a/Plugin/Shipping/Model/Rate/Result.php
+++ b/Plugin/Shipping/Model/Rate/Result.php
@@ -57,11 +57,22 @@ class Result
     public function getAllFreeRates($result)
     {
         $rates = [];
+        $hasFreeShipping = 0;
+        
         foreach ($result ?: [] as $rate) {
-            if ($rate->getPrice() < 0.0001) {
-                $rates[] = $rate;
+            if ($rate->getCarrier() == 'freeshipping') {
+                $hasFreeShipping = 1;
             }
         }
+
+        if($hasFreeShipping) {
+            foreach ($result ?: [] as $rate) {                
+                if ($rate->getPrice() < 0.0001 ) {
+                    $rates[] = $rate;
+                }                            
+            }   
+        }    
+
         return $rates;
     }
 }


### PR DESCRIPTION
With most of my customers, they have a shipping method which is store pickup, which price is 0. So when I installed the module and activated it, the module was removing the courier, which had cost greater than 0. 

eg.

- instore pick up  - 0
- courier - 5

after a catalog price rule for free shipping the courier should remove and add the freeshipping method.
- instore pick up - 0
- free shipping  - 0

So with this commit I made this condition. 

I don't know if others need this functionality more than the module as it is.